### PR TITLE
hide sponsors in sidebar title

### DIFF
--- a/pyconbalkan/core/templates/includes/event_sidebar.html
+++ b/pyconbalkan/core/templates/includes/event_sidebar.html
@@ -28,8 +28,10 @@
 	{% if request.conference.instagram %}<a href="{{ request.conference.instagram }}" class="instagram" target="_blank"></a>{% endif %}
 	{% if request.conference.twitter %}<a href="{{ request.conference.twitter }}" class="twitter" target="_blank"></a>{% endif %}
     </div>
+    {% if sidebar_sponsors %}
     <h3 class="supported-by">Supported by</h3>
     {% for sidebar_sponsor in sidebar_sponsors %}
     <a href="{{ sidebar_sponsor.url }}" class="supported-by-img"><div><img src="{{ sidebar_sponsor.logo.url }}"></div></a>
     {% endfor %}
+    {% endif %}
 </aside>


### PR DESCRIPTION
Hide "sponsored by" title on main page when there are no sponsors to show.

Remember: in order to have sponsor logos visible in sidebar you need to set sponsor to active and set it to belong to this year in admin. I am only mentioning this because they are still hidden as it is now :)