### PR TITLE
Upgrade travis postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
 - '3.6'
 services:
   - postgresql
+addons:
+  postgresql: "10"
 branches:
   only:
   - master


### PR DESCRIPTION
The reason of `django.db.utils.ProgrammingError: syntax error at or near "WITH ORDINALITY"` is Travis' default PostgreSQL version (9.2) is not supported by Django 2.1. Using a newer version postgres solves this issue.

Tests are stil failing, but at least we have one less problem :slightly_smiling_face:  